### PR TITLE
Added defaults for ADDR and TIMEOUT macros

### DIFF
--- a/aravisGigEApp/Db/aravisCamera.template
+++ b/aravisGigEApp/Db/aravisCamera.template
@@ -3,8 +3,8 @@
 #% macro, P, Device Prefix
 #% macro, R, Device Suffix
 #% macro, PORT, Asyn Port name
-#% macro, TIMEOUT, Timeout
-#% macro, ADDR, Asyn Port address
+#% macro, TIMEOUT, Timeout, default 1
+#% macro, ADDR, Asyn Port address, default 0
 
 include "ADBase.template"
 
@@ -101,7 +101,7 @@ record(mbbi, "$(P)$(R)ColorMode_RBV")
 record(ai, "$(P)$(R)COMPLETED_RBV")
 {
    field(DTYP, "asynFloat64")
-   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARAVIS_COMPLETED")
+   field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_COMPLETED")
    field(SCAN, "I/O Intr")
 }
 
@@ -109,7 +109,7 @@ record(ai, "$(P)$(R)COMPLETED_RBV")
 record(ai, "$(P)$(R)FAILURES_RBV")
 {
    field(DTYP, "asynFloat64")
-   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARAVIS_FAILURES")
+   field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_FAILURES")
    field(SCAN, "I/O Intr")
 }
 
@@ -117,20 +117,20 @@ record(ai, "$(P)$(R)FAILURES_RBV")
 record(ai, "$(P)$(R)UNDERRUNS_RBV")
 {
    field(DTYP, "asynFloat64")
-   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARAVIS_UNDERRUNS")
+   field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_UNDERRUNS")
    field(SCAN, "I/O Intr")
 }
 
 record(longout, "$(P)$(R)RESET")
 {
    field(DTYP, "asynInt32")
-   field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARAVIS_RESET")
+   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_RESET")
    field(FLNK, "$(P)$(R)CONNECTION")
 }
 
 record(bi, "$(P)$(R)GETFEATURES_RBV") {
   field(DTYP, "asynInt32")
-  field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARAVIS_GETFEATURES")
+  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_GETFEATURES")
   field(SCAN, "I/O Intr")
   field(ZNAM, "No")
   field(ONAM, "Yes")
@@ -138,7 +138,7 @@ record(bi, "$(P)$(R)GETFEATURES_RBV") {
 
 record(bo, "$(P)$(R)GETFEATURES") {
   field(DTYP, "asynInt32")
-  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARAVIS_GETFEATURES")
+  field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_GETFEATURES")
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(VAL, "1")
@@ -148,7 +148,7 @@ record(bo, "$(P)$(R)GETFEATURES") {
 record(longout, "$(P)$(R)CONNECTION")
 {
    field(DTYP, "asynInt32")
-   field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARAVIS_CONNECTION")
+   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_CONNECTION")
    field(VAL, "1")
    field(PINI, "1")
 }
@@ -164,7 +164,7 @@ record(calcout, "$(P)$(R)CHKCONN")
 
 record(mbbi, "$(P)$(R)LEFTSHIFT_RBV") {
   field(DTYP, "asynInt32")
-  field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARAVIS_LEFTSHIFT")
+  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_LEFTSHIFT")
   field(ZRST, "No")
   field(ZRVL, "0")
   field(ONST, "Yes")
@@ -176,7 +176,7 @@ record(mbbi, "$(P)$(R)LEFTSHIFT_RBV") {
 ## so that a pixel with maximum exposure = 2^16 no matter what the pixel format 
 record(mbbo, "$(P)$(R)LEFTSHIFT") {
   field(DTYP, "asynInt32")
-  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARAVIS_LEFTSHIFT")
+  field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_LEFTSHIFT")
   field(ZRST, "No")
   field(ZRVL, "0")
   field(ONST, "Yes")

--- a/aravisGigEApp/src/makeDbAndEdl.py
+++ b/aravisGigEApp/src/makeDbAndEdl.py
@@ -119,11 +119,10 @@ print '# Macros:'
 print '#% macro, P, Device Prefix'
 print '#% macro, R, Device Suffix'
 print '#% macro, PORT, Asyn Port name'
-print '#% macro, TIMEOUT, Timeout'
-print '#% macro, ADDR, Asyn Port address'
+print '#% macro, TIMEOUT, Timeout, default=1'
+print '#% macro, ADDR, Asyn Port address, default=0'
 print '#%% gui, $(PORT), edmtab, %s.edl, P=$(P),R=$(R)' % camera_name
 print 
-
 
 # for each node
 for node in doneNodes:
@@ -135,7 +134,7 @@ for node in doneNodes:
     if node.nodeName in ["Integer", "IntConverter", "IntSwissKnife"]:
         print 'record(longin, "$(P)$(R)%s_RBV") {' % records[nodeName]
         print '  field(DTYP, "asynInt32")'
-        print '  field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARVI_%s")' % nodeName
+        print '  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARVI_%s")' % nodeName
         print '  field(SCAN, "I/O Intr")'
         print '  field(DISA, "0")'        
         print '}'
@@ -144,14 +143,14 @@ for node in doneNodes:
             continue        
         print 'record(longout, "$(P)$(R)%s") {' % records[nodeName]
         print '  field(DTYP, "asynInt32")'
-        print '  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARVI_%s")' % nodeName
+        print '  field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARVI_%s")' % nodeName
         print '  field(DISA, "0")'
         print '}'
         print        
     elif node.nodeName in ["Boolean"]:
         print 'record(bi, "$(P)$(R)%s_RBV") {' % records[nodeName]
         print '  field(DTYP, "asynInt32")'
-        print '  field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARVI_%s")' % nodeName
+        print '  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARVI_%s")' % nodeName
         print '  field(SCAN, "I/O Intr")'
         print '  field(ZNAM, "No")'
         print '  field(ONAM, "Yes")'                        
@@ -162,7 +161,7 @@ for node in doneNodes:
             continue        
         print 'record(bo, "$(P)$(R)%s") {' % records[nodeName]
         print '  field(DTYP, "asynInt32")'
-        print '  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARVI_%s")' % nodeName
+        print '  field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARVI_%s")' % nodeName
         print '  field(ZNAM, "No")'
         print '  field(ONAM, "Yes")'                                
         print '  field(DISA, "0")'
@@ -171,7 +170,7 @@ for node in doneNodes:
     elif node.nodeName in ["Float", "Converter", "SwissKnife"]:
         print 'record(ai, "$(P)$(R)%s_RBV") {' % records[nodeName]
         print '  field(DTYP, "asynFloat64")'
-        print '  field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARVD_%s")' % nodeName
+        print '  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARVD_%s")' % nodeName
         print '  field(PREC, "3")'        
         print '  field(SCAN, "I/O Intr")'
         print '  field(DISA, "0")'
@@ -181,7 +180,7 @@ for node in doneNodes:
             continue    
         print 'record(ao, "$(P)$(R)%s") {' % records[nodeName]
         print '  field(DTYP, "asynFloat64")'
-        print '  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARVD_%s")' % nodeName
+        print '  field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARVD_%s")' % nodeName
         print '  field(PREC, "3")'
         print '  field(DISA, "0")'
         print '}'
@@ -189,7 +188,7 @@ for node in doneNodes:
     elif node.nodeName in ["StringReg"]:
         print 'record(stringin, "$(P)$(R)%s_RBV") {' % records[nodeName]
         print '  field(DTYP, "asynOctetRead")'
-        print '  field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARVS_%s")' % nodeName
+        print '  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARVS_%s")' % nodeName
         print '  field(SCAN, "I/O Intr")'
         print '  field(DISA, "0")'
         print '}'
@@ -197,7 +196,7 @@ for node in doneNodes:
     elif node.nodeName in ["Command"]:
         print 'record(longout, "$(P)$(R)%s") {' % records[nodeName]
         print '  field(DTYP, "asynInt32")'
-        print '  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARVI_%s")' % nodeName
+        print '  field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARVI_%s")' % nodeName
         print '  field(DISA, "0")'
         print '}'
         print         
@@ -218,7 +217,7 @@ for node in doneNodes:
                 i += 1                
         print 'record(mbbi, "$(P)$(R)%s_RBV") {' % records[nodeName]
         print '  field(DTYP, "asynInt32")'
-        print '  field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARVI_%s")' % nodeName
+        print '  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARVI_%s")' % nodeName
         print enumerations,
         print '  field(SCAN, "I/O Intr")'
         print '  field(DISA, "0")'
@@ -228,7 +227,7 @@ for node in doneNodes:
             continue        
         print 'record(mbbo, "$(P)$(R)%s") {' % records[nodeName]
         print '  field(DTYP, "asynInt32")'
-        print '  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARVI_%s")' % nodeName
+        print '  field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARVI_%s")' % nodeName
         print enumerations,       
         print '  field(DISA, "0")'
         print '}'


### PR DESCRIPTION
Added defaults for ADDR and TIMEOUT macros so we can let them default like we do with our other areaDetector templates