### PR TITLE
Bugfix for the bug where float features were not set on the camera

### DIFF
--- a/aravisGigEApp/src/aravisCamera.cpp
+++ b/aravisGigEApp/src/aravisCamera.cpp
@@ -1390,28 +1390,26 @@ asynStatus aravisCamera::setIntegerValue(const char *feature, epicsInt32 value, 
 asynStatus aravisCamera::setFloatValue(const char *feature, epicsFloat64 value, epicsFloat64 *rbv) {
     const char *functionName = "setFloatValue";
     if (feature == NULL) {
-        ArvGcNode *featureNode = arv_device_get_feature(this->device, feature);
-        *rbv = value;
-        if (!ARV_IS_GC_COMMAND(featureNode)) {
-            asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
-                    "%s:%s: Cannot set float value of a NULL feature\n",
-                    driverName, functionName);
-            return asynError;
-        }
-        asynPrint(  this->pasynUserSelf, ASYN_TRACEIO_DRIVER,
-                "%s:%s: arv_device_set_float_feature_value %s value %f\n",
-                driverName, functionName, feature, value );
-        arv_device_set_float_feature_value (this->device, feature, value);
-        if (rbv != NULL) {
-            *rbv = arv_device_get_float_feature_value (this->device, feature);
-        }
-        if (fabs(value - *rbv) > 0.001) {
-            asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
-                    "%s:%s: feature %s value %f != rbv %f\n",
-                    driverName, functionName, feature, value, *rbv);
-            return asynError;
-        }
+        asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+            "%s:%s: Cannot set float value of a NULL feature\n",
+            driverName, functionName);
+        return asynError;
     }
+
+    asynPrint(  this->pasynUserSelf, ASYN_TRACEIO_DRIVER,
+            "%s:%s: arv_device_set_float_feature_value %s value %f\n",
+            driverName, functionName, feature, value );
+    arv_device_set_float_feature_value (this->device, feature, value);
+    if (rbv != NULL) {
+        *rbv = arv_device_get_float_feature_value (this->device, feature);
+    }
+    if (fabs(value - *rbv) > 0.001) {
+        asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+                "%s:%s: feature %s value %f != rbv %f\n",
+                driverName, functionName, feature, value, *rbv);
+        return asynError;
+    }
+
     return asynSuccess;
 }
 

--- a/aravisGigEApp/src/aravisCamera.cpp
+++ b/aravisGigEApp/src/aravisCamera.cpp
@@ -1402,14 +1402,13 @@ asynStatus aravisCamera::setFloatValue(const char *feature, epicsFloat64 value, 
     arv_device_set_float_feature_value (this->device, feature, value);
     if (rbv != NULL) {
         *rbv = arv_device_get_float_feature_value (this->device, feature);
+        if (fabs(value - *rbv) > 0.001) {
+            asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+                    "%s:%s: feature %s value %f != rbv %f\n",
+                    driverName, functionName, feature, value, *rbv);
+            return asynError;
+        }
     }
-    if (fabs(value - *rbv) > 0.001) {
-        asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
-                "%s:%s: feature %s value %f != rbv %f\n",
-                driverName, functionName, feature, value, *rbv);
-        return asynError;
-    }
-
     return asynSuccess;
 }
 

--- a/aravisGigEApp/src/aravisCamera.cpp
+++ b/aravisGigEApp/src/aravisCamera.cpp
@@ -1393,22 +1393,22 @@ asynStatus aravisCamera::setFloatValue(const char *feature, epicsFloat64 value, 
         ArvGcNode *featureNode = arv_device_get_feature(this->device, feature);
         *rbv = value;
         if (!ARV_IS_GC_COMMAND(featureNode)) {
-        asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+            asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
                     "%s:%s: Cannot set float value of a NULL feature\n",
                     driverName, functionName);
-        return asynError;
-    }
-    asynPrint(  this->pasynUserSelf, ASYN_TRACEIO_DRIVER,
+            return asynError;
+        }
+        asynPrint(  this->pasynUserSelf, ASYN_TRACEIO_DRIVER,
                 "%s:%s: arv_device_set_float_feature_value %s value %f\n",
                 driverName, functionName, feature, value );
-    arv_device_set_float_feature_value (this->device, feature, value);
-    if (rbv != NULL) {
-        *rbv = arv_device_get_float_feature_value (this->device, feature);
-    }
+        arv_device_set_float_feature_value (this->device, feature, value);
+        if (rbv != NULL) {
+            *rbv = arv_device_get_float_feature_value (this->device, feature);
+        }
         if (fabs(value - *rbv) > 0.001) {
             asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
-                        "%s:%s: feature %s value %f != rbv %f\n",
-                        driverName, functionName, feature, value, *rbv);
+                    "%s:%s: feature %s value %f != rbv %f\n",
+                    driverName, functionName, feature, value, *rbv);
             return asynError;
         }
     }


### PR DESCRIPTION
#25 introduced a bug where the whole writeFloatValue was skipped if feature was not NULL, this pull request reverts this change.
I was unable to figure out what the new additions to the function were supposed to do so I just reverted them.