### PR TITLE
re-connect and synchronization

### DIFF
--- a/aravisGigEApp/Db/aravisCamera.template
+++ b/aravisGigEApp/Db/aravisCamera.template
@@ -187,39 +187,15 @@ record(longout, "$(P)$(R)RESET")
    field(FLNK, "$(P)$(R)CONNECTION")
 }
 
-record(bi, "$(P)$(R)GETFEATURES_RBV") {
-  field(DTYP, "asynInt32")
-  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_GETFEATURES")
-  field(SCAN, "I/O Intr")
-  field(ZNAM, "No")
-  field(ONAM, "Yes")
-}
-
-record(bo, "$(P)$(R)GETFEATURES") {
-  field(DTYP, "asynInt32")
-  field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_GETFEATURES")
-  field(ZNAM, "No")
-  field(ONAM, "Yes")
-  field(VAL,  "1")
-  field(PINI, "YES")
-  info(autosaveFields, "DESC VAL")
-}
-
-record(longout, "$(P)$(R)CONNECTION")
+record(bi, "$(P)$(R)CONNECTION")
 {
    field(DTYP, "asynInt32")
-   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_CONNECTION")
-   field(VAL, "1")
-   field(PINI, "1")
-}
-
-record(calcout, "$(P)$(R)CHKCONN")
-{
-   field(SCAN, "1 second")
-   field(INPA, "$(P)$(R)CONNECTION.SEVR CP")
-   field(CALC, "A==0")
-   field(OOPT, "When Non-zero")
-   field(OUT,  "$(P)$(R)CONNECTION.PROC PP")
+   field(INP , "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_CONNECTION")
+   field(SCAN, "I/O Intr")
+   field(ZNAM, "Disconnected")
+   field(ONAM, "Connected")
+   field(ZSV , "MAJOR")
+   alias("$(P)$(R)CONNECTION_RBV")
 }
 
 record(mbbi, "$(P)$(R)LEFTSHIFT_RBV") {

--- a/aravisGigEApp/Db/aravisCamera.template
+++ b/aravisGigEApp/Db/aravisCamera.template
@@ -261,3 +261,11 @@ record(longin, "$(P)$(R)NumExposuresCounter_RBV") {
 record(mbbo, "$(P)$(R)TriggerMode") {
   field(DISA, "1")
 }
+
+record(longout, "$(P)$(R)MTU") {
+  field(DTYP, "asynInt32")
+  field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARVI_GevSCPSPacketSize")
+  field(VAL, "1500")
+  field(PINI, "YES")
+  info(autosaveFields, "DESC HHSV HIHI HIGH HSV LLSV LOLO LOW LSV PINI VAL")
+}

--- a/aravisGigEApp/src/Makefile
+++ b/aravisGigEApp/src/Makefile
@@ -18,6 +18,10 @@ TESTPROD_IOC += testcam
 testcam_SRCS += testcam.cpp
 testcam_LIBS += aravisCamera ADBase asyn dbCore Com
 
+TESTPROD_IOC += testimage
+testimage_SRCS += testimage.cpp
+testimage_LIBS += aravisCamera ADBase asyn dbCore Com
+
 LIBRARY_IOC += aravisCamera
 
 # The following are compiled and added to the support library

--- a/aravisGigEApp/src/Makefile
+++ b/aravisGigEApp/src/Makefile
@@ -16,11 +16,11 @@ inspectcam_SRCS += inspectcam.cpp
 
 TESTPROD_IOC += testcam
 testcam_SRCS += testcam.cpp
-testcam_LIBS += aravisCamera ADBase asyn dbCore Com
+testcam_LIBS += aravisCamera ADBase asyn $(EPICS_BASE_IOC_LIBS)
 
 TESTPROD_IOC += testimage
 testimage_SRCS += testimage.cpp
-testimage_LIBS += aravisCamera ADBase asyn dbCore Com
+testimage_LIBS += aravisCamera ADBase asyn $(EPICS_BASE_IOC_LIBS)
 
 LIBRARY_IOC += aravisCamera
 

--- a/aravisGigEApp/src/Makefile
+++ b/aravisGigEApp/src/Makefile
@@ -11,6 +11,13 @@ include $(TOP)/configure/CONFIG
 #aravisTest_SRCS_DEFAULT += aravisTest.c
 #aravisTest_LIBS += $(EPICS_BASE_IOC_LIBS)
 
+PROD_IOC += inspectcam
+inspectcam_SRCS += inspectcam.cpp
+
+TESTPROD_IOC += testcam
+testcam_SRCS += testcam.cpp
+testcam_LIBS += aravisCamera ADBase asyn dbCore Com
+
 LIBRARY_IOC += aravisCamera
 
 # The following are compiled and added to the support library

--- a/aravisGigEApp/src/adhelper.h
+++ b/aravisGigEApp/src/adhelper.h
@@ -1,0 +1,35 @@
+#ifndef ADHELPER_H
+#define ADHELPER_H
+
+/* areaDetector includes */
+#include <ADDriver.h>
+
+struct NDArrayPtr {
+    NDArray *arr;
+    NDArrayPtr() :arr(0) {}
+    explicit NDArrayPtr(NDArray* arr) :arr(arr) {
+        if(!arr)
+            throw std::runtime_error("Failed to allocate NDArray");
+    }
+    NDArrayPtr(const NDArrayPtr& o) :arr(o.arr) {
+        if(arr) arr->reserve();
+    }
+    ~NDArrayPtr() { reset(); }
+    void reset(NDArray *p=0) {
+        if(arr) arr->release();
+        arr = p;
+    }
+    NDArray& operator*() const { return *arr; }
+    NDArray* operator->() const { return arr; }
+    NDArray* get() const { return arr; }
+    NDArray* release() {
+        NDArray *ret = arr;
+        arr = 0;
+        return ret;
+    }
+    void swap(NDArrayPtr& o) {
+        std::swap(arr, o.arr);
+    }
+};
+
+#endif // ADHELPER_H

--- a/aravisGigEApp/src/aravisCamera.cpp
+++ b/aravisGigEApp/src/aravisCamera.cpp
@@ -1283,10 +1283,6 @@ void aravisCamera::doConnect(Guard& G)
         if (arv_device_get_feature(dev, "AcquisitionFrameRateEnabled")) {
             arv_device_set_integer_feature_value (dev, "AcquisitionFrameRateEnabled", 1);
         }
-    deviceID = arv_camera_get_device_id(this->camera);
-    if (deviceID) status |= setStringParam (ADSerialNumber, deviceID);
-    firmwareVersion = arv_device_get_string_feature_value(this->device, "DeviceFirmwareVersion");
-    if (firmwareVersion) status |= setStringParam (ADFirmwareVersion, firmwareVersion);
 
         // map camera features to AD parameters
         trace("%s:%s mapping features\n", portName, __FUNCTION__);

--- a/aravisGigEApp/src/aravisCamera.cpp
+++ b/aravisGigEApp/src/aravisCamera.cpp
@@ -446,6 +446,28 @@ asynStatus aravisCamera::makeCameraObject() {
                     driverName, functionName);
         return asynError;
     }
+
+    guint32 regval = -1;
+    asynStatus status = asynError;
+    if (arv_device_read_register(this->device, ARV_GVBS_CONTROL_CHANNEL_PRIVILEGE_OFFSET, &regval, NULL)) {
+        if (regval&ARV_GVBS_CONTROL_CHANNEL_PRIVILEGE_CONTROL) {
+            asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
+                        "%s:%s: In control of camera.\n",
+                        driverName, functionName);
+            printf("aravisCamera: I am in control\n");
+            status = asynSuccess;
+        } else {
+            asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+                        "%s:%s: Another client has control of this camera.\n",
+                        driverName, functionName);
+        }
+    } else {
+        asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+                    "%s:%s: Unable to read camera CONTROL_CHANNEL register.  Device not accessible.\n",
+                    driverName, functionName);
+    }
+    if (status) return status;
+
     // Make standard size packets
 //    arv_gv_device_set_packet_size(ARV_GV_DEVICE(this->device), ARV_GV_DEVICE_GVSP_PACKET_SIZE_DEFAULT);
     // Uncomment this line to set jumbo packets

--- a/aravisGigEApp/src/aravisCamera.cpp
+++ b/aravisGigEApp/src/aravisCamera.cpp
@@ -447,7 +447,7 @@ asynStatus aravisCamera::makeCameraObject() {
         return asynError;
     }
     // Make standard size packets
-    arv_gv_device_set_packet_size(ARV_GV_DEVICE(this->device), ARV_GV_DEVICE_GVSP_PACKET_SIZE_DEFAULT);
+//    arv_gv_device_set_packet_size(ARV_GV_DEVICE(this->device), ARV_GV_DEVICE_GVSP_PACKET_SIZE_DEFAULT);
     // Uncomment this line to set jumbo packets
 //    arv_gv_device_set_packet_size(ARV_GV_DEVICE(this->device), 9000);
     /* Store genicam */

--- a/aravisGigEApp/src/aravisCamera.cpp
+++ b/aravisGigEApp/src/aravisCamera.cpp
@@ -298,6 +298,9 @@ public:
     //! flag requests a re-check of payload size due to possible changes
     bool payloadSizeCheck;
 
+    //! clear on init/disconnect, set when first feature scan completes
+    bool scanCompleted;
+
     GWrapper<ArvStream> stream;
     ArvDevice* device;
     ArvGc* genicam;
@@ -488,6 +491,7 @@ aravisCamera::aravisCamera(const char *portName, const char *cameraName,
     ,cameraName(cameraName)
     ,payloadSize(0)
     ,payloadSizeCheck(false)
+    ,scanCompleted(false)
     ,target_state(Connecting)
     ,current_state(Init)
     ,pollingLoop(*this, "aravisPoll", stackSize, epicsThreadPriorityHigh)
@@ -765,7 +769,7 @@ void aravisCamera::run()
                     // stop acquiring
                     acquiring = false;
                     doAcquireStop(G);
-                } else if(!acquiring && acq) {
+                } else if(!acquiring && acq && scanCompleted) {
                     // start acquiring
                     doAcquireStart(G);
                     acquiring = true;
@@ -864,6 +868,8 @@ void aravisCamera::runScanner()
             sync_cnt = 0;
             setIntegerParam(AravisSyncd, sync_cnt);
             callParamCallbacks();
+
+            scanCompleted = false;
 
             UnGuard U(G);
             scannerEvent.wait();
@@ -1064,6 +1070,7 @@ void aravisCamera::runScanner()
 
                     callParamCallbacks();
 
+                    // short wait between each feature
                     {
                         UnGuard U(G);
                         scannerEvent.wait(0.01);
@@ -1081,6 +1088,11 @@ void aravisCamera::runScanner()
             callParamCallbacks();
             trace("%s:%s scanner complete %u\n", portName, __FUNCTION__, sync_cnt);
 
+            if(!scanCompleted)
+                pollingEvent.signal();
+            scanCompleted = true;
+
+            // longer wait between scans
             UnGuard U(G);
             scannerEvent.wait(0.1);
         }
@@ -1095,7 +1107,6 @@ void aravisCamera::doCleanup(Guard &G)
     /* Tell areaDetector it is no longer acquiring */
     setIntegerParam(AravisConnection, 0);
     setIntegerParam(ADStatus, ADStatusIdle);
-    setIntegerParam(ADAcquire, 0); //TODO wait for initial sync and then begin acquire automatically
 
     GWrapper<ArvCamera> cam;
     GWrapper<ArvStream> strm;

--- a/aravisGigEApp/src/aravisCamera.cpp
+++ b/aravisGigEApp/src/aravisCamera.cpp
@@ -931,6 +931,24 @@ void aravisCamera::runScanner()
                             // hum, we shouldn't have allowed this in writeInt32()
                             // soft fail to a default
                             px = &pix_lookup_arr[0];
+                        } else {
+                            guint nfmts = 0;
+
+                            const gint64 *fmts = arv_camera_get_available_pixel_formats(cam, &nfmts);
+
+                            bool match = false;
+                            for(guint i=0; i<nfmts; i++) {
+                                if(fmts[i]==px->fmt) {
+                                    match = true;
+                                    break;
+                                }
+                            }
+
+                            if(!match) {
+                                px = &pix_lookup_arr[0];
+                                error("%s:%s current pixel format not supported by camera.  Fallback to default\n",
+                                      portName, __FUNCTION__);
+                            }
                         }
                         old_val = feat->asyn2arv(px->fmt);
 
@@ -1583,8 +1601,9 @@ asynStatus aravisCamera::writeInt32(asynUser *pasynUser, epicsInt32 value)
             status = asynError;
             setIntegerParam(function, rbv); // restore previous
 
-        } else {
+        } else if (current_state==Connected) {
             guint nfmts = 0;
+
             const gint64 *fmts = arv_camera_get_available_pixel_formats(camera, &nfmts);
 
             bool match = false;
@@ -1600,7 +1619,7 @@ asynStatus aravisCamera::writeInt32(asynUser *pasynUser, epicsInt32 value)
                 status = asynError;
                 setIntegerParam(function, rbv); // restore previous
 
-            } else if(current_state==Connected) {
+            } else {
                 epicsGuard<epicsMutex> IO(arvLock);
 
                 arv_camera_set_pixel_format(camera, px->fmt);
@@ -1620,9 +1639,11 @@ asynStatus aravisCamera::writeInt32(asynUser *pasynUser, epicsInt32 value)
                     error("%s:%s failed to set PixelFormat\n", portName, __FUNCTION__);
                     break;
                 }
-            } else {
-                status = asynSuccess;
             }
+        } else {
+            // can't validate further when no camera connected.
+            // depend on scanner sync to handle this...
+            status = asynSuccess;
         }
 
     } else if (function == ADReverseX || function == ADReverseY || function == ADFrameType) {

--- a/aravisGigEApp/src/aravisCamera.cpp
+++ b/aravisGigEApp/src/aravisCamera.cpp
@@ -709,12 +709,12 @@ void aravisCamera::run()
         try {
             switch(current_state) {
             case Init:
-                // notify for lazily created parameters
+                // mark read-back parameters as INVALID
                 for(interestingFeatures_t::const_iterator it = interestingFeatures.begin(),
                                                          end = interestingFeatures.end();
                     it != end; ++it)
                 {
-                    if(it->first>=0)
+                    if(it->first>=0 && !it->second.userSetting)
                         setParamStatus(it->first, asynError);
                 }
                 callParamCallbacks();
@@ -954,8 +954,8 @@ void aravisCamera::runScanner()
 
                 bool forcestore = changed && userSetting;
                 if(forcestore) {
-                    error("%s:%s param %s marked as setting w/o a setting value.  Forcing to current value.\n",
-                          portName, __FUNCTION__, feat->activeName.c_str());
+                    error("%s:%s param %s (%d) marked as setting w/o a setting value.  Forcing to current value.\n",
+                          portName, __FUNCTION__, feat->activeName.c_str(), feat->param);
                 }
 
                 {
@@ -1464,11 +1464,12 @@ asynStatus aravisCamera::writeInt32(asynUser *pasynUser, epicsInt32 value)
 
         if(!feat->userSetting) {
             if(current_state==Init) {
-                trace("%s:%s mark as setting %s w/ %d\n",
-                      portName, __FUNCTION__, reasonName, (int)value);
+                trace("%s:%s mark as setting %s(%d) w/ %d\n",
+                      portName, __FUNCTION__, reasonName, function, (int)value);
                 feat->userSetting = true;
             } else {
-                error("%s:%s can't mark as setting %s after Init\n", portName, __FUNCTION__, feat->activeName.c_str());
+                error("%s:%s can't mark as setting %s(%d) w/ %d\n",
+                      portName, __FUNCTION__, reasonName, function, (int)value);
             }
         }
 
@@ -1497,12 +1498,12 @@ asynStatus aravisCamera::writeInt32(asynUser *pasynUser, epicsInt32 value)
         }
 
         status = setIntegerParam(function, value);
+        setParamStatus(function, asynSuccess);
 
         if(err) {
             error("Error setting %s : %s\n", feat->activeName.c_str(), err->message);
             status = asynError;
         } else {
-            setParamStatus(function, asynSuccess);
             payloadSizeCheck = true;
         }
 
@@ -1653,11 +1654,12 @@ asynStatus aravisCamera::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
 
         if(!feat->userSetting) {
             if(current_state==Init) {
-                trace("%s:%s mark as setting %s w/ %f\n",
-                      portName, __FUNCTION__, feat->activeName.c_str(), value);
+                trace("%s:%s mark as setting %s(%d) w/ %f\n",
+                      portName, __FUNCTION__, reasonName, function, value);
                 feat->userSetting = true;
             } else {
-                error("%s:%s can't mark as setting %s after Init\n", portName, __FUNCTION__, feat->activeName.c_str());
+                error("%s:%s can't mark as setting %s(%d) w/ %f\n",
+                      portName, __FUNCTION__, reasonName, function, value);
             }
         }
 
@@ -1690,6 +1692,7 @@ asynStatus aravisCamera::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
         }
 
         status = setDoubleParam(function, value);
+        setParamStatus(function, asynSuccess);
 
         if(err) {
             error("Error setting %s : %s\n", feat->activeName.c_str(), err->message);
@@ -1797,6 +1800,57 @@ void aravisCamera::report(FILE *fp, int details)
 #undef SHOW
         }
         fprintf(fp, " Acquring: %c\n", stream.get() ? 'Y' : 'N');
+
+        if(details==1) {
+            fprintf(fp, "Interesting features\n");
+            for(interestingFeatures_t::const_iterator it = interestingFeatures.begin(), end = interestingFeatures.end();
+                it != end; ++it)
+            {
+                const Feature& feat = it->second;
+
+                if(feat.param<0) continue; // skip specials
+
+                const char *name = "<Error>";
+                getParamName(feat.param, &name);
+
+                if(current_state!=Connected || feat.activeName.empty()) {
+                    fprintf(fp, "  %s (%d) <=> Not mapped\n", name, (int)feat.param);
+                    continue;
+                }
+
+                fprintf(fp, "  %s (%d) <=> %s ", name, (int)feat.param, feat.activeName.c_str());
+                asynStatus sts;
+                switch(feat.type) {
+                case asynParamInt32: {
+                    int val=0;
+                    sts = getIntegerParam(feat.param, &val);
+                    if(!sts)
+                        fprintf(fp, "int:%d\n", val);
+                }
+                    break;
+                case asynParamFloat64: {
+                    double val=0;
+                    sts = getDoubleParam(feat.param, &val);
+                    if(!sts)
+                        fprintf(fp, "flt:%g\n", val);
+                }
+                    break;
+                case asynParamOctet: {
+                    char buf[100];
+                    sts = getStringParam(feat.param, sizeof(buf)-1, buf);
+                    buf[99] = '\0';
+                    if(!sts)
+                        fprintf(fp, "str:\"%s\"\n", buf);
+                }
+                    break;
+                default:
+                    sts = asynError;
+                }
+
+                if(sts)
+                    fprintf(fp, "<Error>\n");
+            }
+        }
 
     } CATCH(pasynUserSelf)
 

--- a/aravisGigEApp/src/aravisCamera.cpp
+++ b/aravisGigEApp/src/aravisCamera.cpp
@@ -982,6 +982,7 @@ void aravisCamera::runScanner()
                         break;
 
                     case Feature::String:
+                        //TODO: handle return NULL
                         new_str = arv_gc_string_get_value(ARV_GC_STRING(node), gerr.get());
                         changed|= !gerr && strcmp(&old_str[0], new_str.c_str())!=0;
                         if(userSetting && changed && nchanges<3) {
@@ -1775,7 +1776,7 @@ void aravisCamera::report(FILE *fp, int details)
     fprintf(fp, "Aravis GigE detector %s\n", this->portName);
     try {
         Guard G(*this);
-        fprintf(fp, " State");
+        fprintf(fp, " Current State: ");
         switch(current_state) {
 #define SHOW(ST) case ST: fprintf(fp, " " #ST "\n"); break
         SHOW(Init);
@@ -1785,6 +1786,17 @@ void aravisCamera::report(FILE *fp, int details)
         SHOW(Shutdown);
 #undef SHOW
         }
+        fprintf(fp, " Target State: ");
+        switch(target_state) {
+#define SHOW(ST) case ST: fprintf(fp, " " #ST "\n"); break
+        SHOW(Init);
+        SHOW(RetryWait);
+        SHOW(Connecting);
+        SHOW(Connected);
+        SHOW(Shutdown);
+#undef SHOW
+        }
+        fprintf(fp, " Acquring: %c\n", stream.get() ? 'Y' : 'N');
 
     } CATCH(pasynUserSelf)
 

--- a/aravisGigEApp/src/aravisCamera.cpp
+++ b/aravisGigEApp/src/aravisCamera.cpp
@@ -315,6 +315,11 @@ public:
     } target_state,  // updated by various
       current_state; // updated only by worker thread
 
+    void setTargetState(state_t s) {
+        if(target_state!=Shutdown)
+            target_state = s;
+    }
+
     int AravisCompleted;
     #define FIRST_ARAVIS_CAMERA_PARAM AravisCompleted
     int AravisFailures;
@@ -709,7 +714,7 @@ void aravisCamera::run()
     bool acquiring = false;
     trace("%s: poller starting\n", portName);
 
-    while(current_state!=Shutdown) {
+    while(current_state!=Shutdown && target_state!=Shutdown) {
         try {
             switch(current_state) {
             case Init:
@@ -722,7 +727,7 @@ void aravisCamera::run()
                         setParamStatus(it->first, asynError);
                 }
                 callParamCallbacks();
-                target_state = Connecting;
+                setTargetState(Connecting);
                 break;
 
             case RetryWait:
@@ -733,11 +738,11 @@ void aravisCamera::run()
                 ok = !pollingEvent.wait(5.0);
             }
                 if(ok && target_state==RetryWait)
-                    target_state = Connecting;
+                    setTargetState(Connecting);
                 break;
 
             case Connecting:
-                target_state = Connected;
+                setTargetState(Connected);
                 acquiring = false;
                 doCleanup(G);
                 doConnect(G);
@@ -835,7 +840,7 @@ void aravisCamera::run()
         }catch(std::exception& e) {
             error("%s:%s: Error in worker: %s\n",
                   portName, __FUNCTION__, e.what());
-            target_state = RetryWait;
+            setTargetState(RetryWait);
         }
 
         if(current_state != target_state) {
@@ -1177,7 +1182,7 @@ void aravisCamera::doConnect(Guard& G)
     // if camera name not specified, then bail early
     if(cameraName.empty()) {
         trace("%s:%s no cameraName\n", portName, __FUNCTION__);
-        target_state = RetryWait;
+        setTargetState(RetryWait);
         return;
     }
 
@@ -1193,6 +1198,7 @@ void aravisCamera::doConnect(Guard& G)
         UnGuard U(G);
         epicsGuard<epicsMutex> IO(arvLock);
 
+        trace("%s:%s Connect camera \"%s\"\n", portName, __FUNCTION__, cameraName.c_str());
         cam.reset(arv_camera_new (cameraName.c_str()));
         if(!cam)
             throw std::runtime_error(cameraName+": No such camera");
@@ -1462,7 +1468,7 @@ void aravisCamera::dropConnection()
 {
     error("%s:%s\n", portName, __FUNCTION__);
     if(target_state!=Shutdown)
-        target_state = RetryWait;
+        setTargetState(RetryWait);
     pollingEvent.signal();
 }
 
@@ -1791,15 +1797,15 @@ asynStatus aravisCamera::writeOctet(asynUser *pasynUser, const char *value,
         setStringParam(function, value);
         cameraName.swap(name);
         if(target_state==Connected)
-            target_state = Connecting;
+            setTargetState(Connecting);
         else if(target_state!=Shutdown)
-            target_state = RetryWait;
+            setTargetState(RetryWait);
         dropConnection();
 
         *nActual = maxChars;
         status = asynSuccess;
 
-        trace("%s:%s change camera name \"%s\" -> \"%s\"",
+        trace("%s:%s change camera name \"%s\" -> \"%s\"\n",
               portName, __FUNCTION__, name.c_str(), cameraName.c_str());
 
     } else if(function < FIRST_ARAVIS_CAMERA_PARAM) {

--- a/aravisGigEApp/src/ghelper.h
+++ b/aravisGigEApp/src/ghelper.h
@@ -1,0 +1,68 @@
+#ifndef GHELPER_H
+#define GHELPER_H
+
+#include <stdexcept>
+
+extern "C" {
+    #include <arv.h>
+}
+
+//! Smart-ish pointer using GObject ref counting
+template<typename T>
+struct GWrapper {
+    GWrapper() :ptr(0) {}
+    GWrapper(T* p) :ptr(p) {
+        if(!p)
+            throw std::bad_alloc();
+    }
+    GWrapper(const GWrapper& o) :ptr(o.ptr) {
+        if(ptr) g_object_ref(ptr);
+    }
+    ~GWrapper() { reset(); }
+    void reset(T* p=0) {
+        if(ptr) g_object_unref(ptr);
+        ptr = p;
+    }
+    GWrapper& operator=(const GWrapper& o) {
+        if(ptr!=o.ptr) {
+            if(o.ptr) g_object_ref(o.ptr);
+            if(ptr)   g_object_unref(ptr);
+            ptr = o.ptr;
+        }
+        return *this;
+    }
+    void swap(GWrapper& o) {
+        std::swap(ptr, o.ptr);
+    }
+    T* get() const { return ptr; }
+    operator T*() const { return ptr; }
+    T* release() {
+        T* ret = ptr;
+        ptr = 0;
+        return ret;
+    }
+
+private:
+    T *ptr;
+};
+
+// Helper to ensure that GError is free'd
+struct GErrorHelper {
+    GError *err;
+    GErrorHelper() :err(0) {}
+    ~GErrorHelper() {
+        if(err) g_error_free(err);
+    }
+    GError** get() {
+        return &err;
+    }
+    operator GError*() const {
+        return err;
+    }
+    GError* operator->() const {
+        return err;
+    }
+};
+
+
+#endif // GHELPER_H

--- a/aravisGigEApp/src/inspectcam.cpp
+++ b/aravisGigEApp/src/inspectcam.cpp
@@ -1,0 +1,118 @@
+/* Test/demo to see what information can be extracted
+ * from aravis parsed xml (genicam) tree.
+ */
+#include <stdexcept>
+#include <stdio.h>
+
+#include "ghelper.h"
+
+namespace {
+
+void inspect_node(ArvDomNode *node, int indent)
+{
+    GErrorHelper err;
+    const char *tag = arv_dom_node_get_node_name(node);
+
+    printf("%*s", indent, tag);
+
+    if(ARV_IS_GC_FEATURE_NODE(node)) {
+        const char *name = arv_gc_feature_node_get_name(ARV_GC_FEATURE_NODE(node));
+        printf(" %s", name);
+    }
+
+    /* order of tests is important as, eg.
+     *    ENUMERATION is also INTEGER and STRING
+     *    BOOLEAN is also INTEGER
+     */
+
+    if(ARV_IS_GC_ENUMERATION(node)) { // <Enumeration>
+        ArvGcEnumeration *feat = ARV_GC_ENUMERATION(node);
+        printf(" enum %s (%d)",
+               arv_gc_enumeration_get_string_value(feat, err.get()),
+               (int)arv_gc_enumeration_get_int_value(feat, err.get()));
+
+        const GSList *entries = arv_gc_enumeration_get_entries(feat);
+        if(entries) {
+            for(const GSList *it = entries; it; it = it->next) {
+                ArvGcEnumEntry *ent = ARV_GC_ENUM_ENTRY(it->data);
+                if(!ent) continue;
+
+                printf(" %s:%d,",
+                       arv_gc_feature_node_get_name(ARV_GC_FEATURE_NODE(ent)),
+                       (int)arv_gc_enum_entry_get_value(ent, err.get())
+                       );
+            }
+        }
+
+    } else if(ARV_IS_GC_BOOLEAN(node)) { // <Boolean>
+        printf(" bool %d",
+               arv_gc_boolean_get_value(ARV_GC_BOOLEAN(node), err.get()));
+
+    } else if(ARV_IS_GC_COMMAND(node)) { // <Command>
+        printf(" command");
+
+    } else if(ARV_IS_GC_INTEGER(node)) { // <Integer>, <IntReg>, or <MaskedIntReg>
+        printf(" integer %d",
+               (int)arv_gc_integer_get_value(ARV_GC_INTEGER(node), err.get()));
+
+    } else if(ARV_IS_GC_FLOAT(node)) { // <Float> or <FloatReg>
+        printf(" float %f",
+               arv_gc_float_get_value(ARV_GC_FLOAT(node), err.get()));
+
+    } else if(ARV_IS_GC_STRING(node)) {  // <StringReg>
+        printf(" string %s",
+               arv_gc_string_get_value(ARV_GC_STRING(node), err.get()));
+
+    } else if(ARV_IS_GC_FEATURE_NODE(node)) { // unhandled feature node type?
+        printf(" feature %s",
+               arv_gc_feature_node_get_value_as_string(ARV_GC_FEATURE_NODE(node), err.get()));
+
+    } else { // non-feature node
+        const char * val = arv_dom_node_get_node_value(node);
+        if(val)
+            printf(" \"%s\"", val);
+    }
+
+    if(err) {
+        printf("(Error: %s)\n", err->message);
+    } else {
+        printf("\n");
+    }
+
+    ArvDomNodeList* nodes(arv_dom_node_get_child_nodes(node));
+
+    for(unsigned i=0, len=arv_dom_node_list_get_length(nodes);
+        i < len; i++)
+    {
+        ArvDomNode *cnode = arv_dom_node_list_get_item(nodes, i);
+        if(!cnode) continue;
+
+        inspect_node(cnode, indent+4);
+    }
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    try {
+        if(argc<2) {
+            fprintf(stderr, "Usage: %s <camera_name>\n", argv[0]);
+            return 2;
+        }
+
+        // Search for camera name and build ArvCamera if found
+        GWrapper<ArvCamera> cam(arv_camera_new(argv[1]));
+        // extract borrowed references
+        ArvDevice* dev(arv_camera_get_device(cam));
+        ArvGc* gc(arv_device_get_genicam(dev));
+
+        // Note that ArvGc derives from ArvDomDocument -> ArvDomNode -> GObject
+        inspect_node(ARV_DOM_NODE(gc), 0);
+
+        return 0;
+    } catch(std::exception& e) {
+        fprintf(stderr, "Unhandled exception: %s\n", e.what());
+        return 2;
+    }
+}

--- a/aravisGigEApp/src/testcam.cpp
+++ b/aravisGigEApp/src/testcam.cpp
@@ -138,6 +138,7 @@ MAIN(testcam)
 
         EPICS_EXPORT_PFUNC(aravisCameraRegister)();
 
+        testDiag("Direct connect for setup");
         cam.reset(arv_camera_new("Aravis-GV01"));
         if(!cam)
             testAbort("Can't get direct connection to camera");
@@ -147,6 +148,7 @@ MAIN(testcam)
 
         dev = NULL;
         cam.reset();
+        testDiag("Close direct connect");
 
         testDiag("Create port");
         if(aravisCameraConfig("DUT", "Aravis-GV01", 0, 0, 0, 0)!=asynSuccess)
@@ -182,7 +184,7 @@ MAIN(testcam)
         dev = NULL;
         cam.reset();
 
-        setString("ARAVIS_CAMNAME", "invalid");
+        setString("ARAVIS_CAMNAME", "");
         testDiag("Wait for disconnect");
         for(unsigned i=0; i<10; i++) {
             if(i==9)
@@ -195,6 +197,7 @@ MAIN(testcam)
 
         setupParams();
 
+        testDiag("Direct connect for setup");
         cam.reset(arv_camera_new("Aravis-GV01"));
         if(!cam)
             testAbort("Can't get direct connection to camera");
@@ -204,6 +207,7 @@ MAIN(testcam)
 
         dev = NULL;
         cam.reset();
+        testDiag("Close direct connect");
 
         testDiag("Start re-connect");
         setString("ARAVIS_CAMNAME", "Aravis-GV01");

--- a/aravisGigEApp/src/testcam.cpp
+++ b/aravisGigEApp/src/testcam.cpp
@@ -232,6 +232,8 @@ MAIN(testcam)
     }
     cam.reset();
 
+    arv_shutdown();
+
     testDiag("Exit");
     epicsExit(testDone());
     return 2; // not reached

--- a/aravisGigEApp/src/testcam.cpp
+++ b/aravisGigEApp/src/testcam.cpp
@@ -1,0 +1,317 @@
+// Test (re)connection and feature <-> param synchronization
+#include <string>
+#include <vector>
+#include <sstream>
+
+#include <string.h>
+
+#include <epicsUnitTest.h>
+#include <testMain.h>
+
+#include <ADDriver.h> /* for AD*String */
+
+#include <epicsExit.h>
+#include <epicsExport.h>
+#include <epicsThread.h>
+#include <initHooks.h>
+#include <asynDriver.h>
+#include <asynPortClient.h>
+#include <shareLib.h>
+
+#include "ghelper.h"
+
+// paramErrors.h isn't installed :(
+#define asynParamAlreadyExists (asynStatus)(asynDisabled + 1)
+#define asynParamNotFound      (asynStatus)(asynDisabled + 2)
+#define asynParamWrongType     (asynStatus)(asynDisabled + 3)
+#define asynParamBadIndex      (asynStatus)(asynDisabled + 4)
+#define asynParamUndefined     (asynStatus)(asynDisabled + 5)
+
+extern "C" {
+int asynSetTraceMask(const char *portName,int addr,int mask);
+
+extern REGISTRAR EPICS_EXPORT_PFUNC(aravisCameraRegister);
+
+// must match definition in aravisCamera.cpp
+int aravisCameraConfig(const char *portName, const char *cameraName,
+                                 int maxBuffers, size_t maxMemory, int priority, int stackSize);
+} // extern "C"
+
+namespace {
+
+GWrapper<ArvCamera> cam;
+ArvDevice *dev;
+
+void testFeature(const char *name, const char *expect)
+{
+    ArvGcNode *node = arv_gc_get_node(arv_device_get_genicam(dev), name);
+    if(!node) {
+        testFail("Get Feature %s which isn't a feature", name);
+        return;
+    }
+    GErrorHelper err;
+    std::ostringstream actual;
+    if(ARV_IS_GC_INTEGER(node)) {
+        guint64 val = arv_gc_integer_get_value(ARV_GC_INTEGER(node), err.get());
+        actual << val;
+    } else if(ARV_IS_GC_FLOAT(node)) {
+        double val = arv_gc_float_get_value(ARV_GC_FLOAT(node), err.get());
+        actual << val;
+    } else if(ARV_IS_GC_STRING(node)) {
+        const char* val = arv_gc_string_get_value(ARV_GC_STRING(node), err.get());
+        actual << val;
+    } else {
+        testFail("Get Feature %s has unsupported type\n", name);
+        return;
+    }
+    std::string act(actual.str());
+
+    if(err)
+        testFail("Get Feature %s -> Error: %s", name, err->message);
+    else
+        testOk(strcmp(act.c_str(), expect)==0, "Get Feature %s -> \"%s\" (actual \"%s\")",
+               name, expect, act.c_str());
+}
+
+void setFeature(const char *name, const char *value)
+{
+    ArvGcNode *node = arv_gc_get_node(arv_device_get_genicam(dev), name);
+    GErrorHelper err;
+    arv_gc_feature_node_set_value_from_string(ARV_GC_FEATURE_NODE(node), value, err.get());
+    if(err)
+        testFail("Set Feature %s <- %s Error: %s", name, value, err->message);
+    else
+        testPass("Set Feature %s <- %s", name, value);
+}
+
+void setString(const char *name, const char *value)
+{
+    asynOctetClient C("DUT", -1, name);
+    size_t actual = 0;
+    asynStatus sts = C.write(value, strlen(value), &actual);
+    testOk(sts==asynSuccess && actual==strlen(value), "Set %s -> \"%s\"", name, value);
+}
+
+//void setInt(const char *name, epicsInt32 val) {
+//    asynInt32Client C("DUT", -1, name);
+//    testOk(C.write(val)==asynSuccess, "Set %s = %d", name, (int)val);
+//}
+
+epicsInt32 readInt(const char *name) {
+    asynInt32Client C("DUT", -1, name);
+    epicsInt32 ret;
+    int ok = C.read(&ret)==asynSuccess;
+    if(!ok) testAbort("Failed to read %s", name);
+    return ret;
+}
+
+void setFlt(const char *name, double val) {
+    asynFloat64Client C("DUT", -1, name);
+    testOk(C.write(val)==asynSuccess, "Set %s = %f", name, val);
+}
+
+void waitSyncd()
+{
+    epicsInt32 A = 0, B = 0;
+    testDiag("wait for scanner thread to make one cycle");
+    for(unsigned i=0; i<10; i++) {
+        if(i==9)
+            throw std::runtime_error("Timeout waiting for sync");
+
+        B = readInt("ARAVIS_SYNCD");
+        if(A!=0 && B!=0 && A!=B)
+            break;
+        A=B;
+        epicsThreadSleep(1.0);
+    }
+    testDiag("scanner cycle complete");
+}
+
+void testInt(const char *name, epicsInt32 expect, bool defined=true)
+{
+    asynInt32Client C("DUT", -1, name);
+    epicsInt32 ret;
+    asynStatus sts = C.read(&ret);
+    if(sts!=asynSuccess)
+        testOk(!defined, "Get %s -> Error %d\n", name, (int)sts);
+    else
+        testOk(defined && ret==expect,
+                "Get %s -> %d (actual %d)", name, (int)expect, (int)ret);
+}
+
+void testFlt(const char *name, double expect, bool defined=true)
+{
+    asynFloat64Client C("DUT", -1, name);
+    double ret;
+    asynStatus sts = C.read(&ret);
+    if(sts!=asynSuccess)
+        testOk(!defined, "Get %s -> Error %d\n", name, (int)sts);
+    else
+        testOk(defined && ret==expect,
+                "Get %s -> %f (actual %f)", name, expect, ret);
+}
+
+void testString(const char *name, const char *expect, bool defined=true) {
+    asynOctetClient C("DUT", -1, name);
+    std::vector<char> buf(strlen(expect)+10);
+    size_t act;
+    asynStatus sts = C.read(&buf[0], buf.size(), &act, NULL);
+    buf.back()='\0';
+    if(sts!=asynSuccess)
+        testOk(!defined, "Get %s -> Error %d\n", name, (int)sts);
+    else
+        testOk(defined && strcmp(expect, &buf[0])==0,
+                "Get %s -> \"%s\" (actual \"%s\")", name, expect, &buf[0]);
+}
+
+void prepareCam()
+{
+    testDiag("Prepare camera");
+
+    setFeature("TestRegister", "40");
+    setFeature("GainRaw", "10");
+    setFeature("ExposureTimeAbs", "30");
+
+    testFeature("TestRegister", "40");
+    testFeature("GainRaw", "10");
+    testFeature("ExposureTimeAbs", "30");
+}
+
+void setupParams()
+{
+    testDiag("lazy create of feature parameters");
+
+    setFlt(ADAcquireTimeString, 10e-6);
+
+    setFlt(ADGainString, 2.0);
+
+    testInt("ARVI_TestRegister", 0, false); // a read-back (we will not set)
+    testString(ADManufacturerString, "", false);
+}
+
+void postConnect()
+{
+    testDiag("Check post connect, after initial sync");
+
+    testString(ADManufacturerString, "Aravis");
+
+    // our settings should be pushed to camera
+    testFlt(ADGainString, 2.0);
+    testFeature("GainRaw", "2");
+
+    testFlt(ADAcquireTimeString, 10e-6);
+    testFeature("ExposureTimeAbs", "10");
+
+    // readback params should be updated from camera
+    testInt("ARVI_TestRegister", 0x28);
+    testFeature("TestRegister", "40");
+
+}
+
+} // namespace
+
+MAIN(testcam)
+{
+    testPlan(36);
+    try {
+
+        EPICS_EXPORT_PFUNC(aravisCameraRegister)();
+
+        cam.reset(arv_camera_new("Aravis-GV01"));
+        if(!cam)
+            testAbort("Can't get direct connection to camera");
+        dev = arv_camera_get_device(cam);
+
+        prepareCam();
+
+        dev = NULL;
+        cam.reset();
+
+        testDiag("Create port");
+        if(aravisCameraConfig("DUT", "Aravis-GV01", 10, 10000, 0, 0)!=asynSuccess)
+            testAbort("Unable to create port");
+
+        asynSetTraceMask("DUT", -1, 0x3f);
+
+        setupParams();
+
+        initHookAnnounce(initHookAfterIocRunning);
+        testDiag("Announced IocRunning");
+
+        testDiag("Wait for connect");
+        for(unsigned i=0; i<10; i++) {
+            if(i==9)
+                testAbort("No connect");
+            else if(readInt("ARAVIS_CONNECTION")==1)
+                break;
+            epicsThreadSleep(1.0);
+        }
+        testDiag("Connected");
+        waitSyncd();
+
+        testDiag("Second connection directly to camera");
+        cam.reset(arv_camera_new("Aravis-GV01"));
+        if(!cam)
+            testAbort("Can't get direct connection to camera");
+        dev = arv_camera_get_device(cam);
+
+        postConnect();
+
+        testDiag("Disconnnect all");
+        dev = NULL;
+        cam.reset();
+
+        setString("ARAVIS_CAMNAME", "invalid");
+        testDiag("Wait for disconnect");
+        for(unsigned i=0; i<10; i++) {
+            if(i==9)
+                testAbort("No disconnect");
+            else if(readInt("ARAVIS_CONNECTION")==0)
+                break;
+            epicsThreadSleep(1.0);
+        }
+        testDiag("Disconnected");
+
+        setupParams();
+
+        cam.reset(arv_camera_new("Aravis-GV01"));
+        if(!cam)
+            testAbort("Can't get direct connection to camera");
+        dev = arv_camera_get_device(cam);
+
+        prepareCam();
+
+        dev = NULL;
+        cam.reset();
+
+        testDiag("Start re-connect");
+        setString("ARAVIS_CAMNAME", "Aravis-GV01");
+
+        testDiag("Wait for connect");
+        for(unsigned i=0; i<10; i++) {
+            if(i==9)
+                testAbort("No connect");
+            else if(readInt("ARAVIS_CONNECTION")==1)
+                break;
+            epicsThreadSleep(1.0);
+        }
+        testDiag("Connected");
+        waitSyncd();
+
+        testDiag("Second connection directly to camera");
+        cam.reset(arv_camera_new("Aravis-GV01"));
+        if(!cam)
+            testAbort("Can't get direct connection to camera");
+        dev = arv_camera_get_device(cam);
+
+        postConnect();
+
+    } catch(std::exception& e) {
+        testAbort("Unexpected exception: %s", e.what());
+    }
+    cam.reset();
+
+    testDiag("Exit");
+    epicsExit(testDone());
+    return 2; // not reached
+}

--- a/aravisGigEApp/src/testcam.cpp
+++ b/aravisGigEApp/src/testcam.cpp
@@ -19,6 +19,7 @@
 #include <shareLib.h>
 
 #include "ghelper.h"
+#include "testhelper.h"
 
 // paramErrors.h isn't installed :(
 #define asynParamAlreadyExists (asynStatus)(asynDisabled + 1)
@@ -82,86 +83,6 @@ void setFeature(const char *name, const char *value)
         testFail("Set Feature %s <- %s Error: %s", name, value, err->message);
     else
         testPass("Set Feature %s <- %s", name, value);
-}
-
-void setString(const char *name, const char *value)
-{
-    asynOctetClient C("DUT", -1, name);
-    size_t actual = 0;
-    asynStatus sts = C.write(value, strlen(value), &actual);
-    testOk(sts==asynSuccess && actual==strlen(value), "Set %s -> \"%s\"", name, value);
-}
-
-//void setInt(const char *name, epicsInt32 val) {
-//    asynInt32Client C("DUT", -1, name);
-//    testOk(C.write(val)==asynSuccess, "Set %s = %d", name, (int)val);
-//}
-
-epicsInt32 readInt(const char *name) {
-    asynInt32Client C("DUT", -1, name);
-    epicsInt32 ret;
-    int ok = C.read(&ret)==asynSuccess;
-    if(!ok) testAbort("Failed to read %s", name);
-    return ret;
-}
-
-void setFlt(const char *name, double val) {
-    asynFloat64Client C("DUT", -1, name);
-    testOk(C.write(val)==asynSuccess, "Set %s = %f", name, val);
-}
-
-void waitSyncd()
-{
-    epicsInt32 A = 0, B = 0;
-    testDiag("wait for scanner thread to make one cycle");
-    for(unsigned i=0; i<10; i++) {
-        if(i==9)
-            throw std::runtime_error("Timeout waiting for sync");
-
-        B = readInt("ARAVIS_SYNCD");
-        if(A!=0 && B!=0 && A!=B)
-            break;
-        A=B;
-        epicsThreadSleep(1.0);
-    }
-    testDiag("scanner cycle complete");
-}
-
-void testInt(const char *name, epicsInt32 expect, bool defined=true)
-{
-    asynInt32Client C("DUT", -1, name);
-    epicsInt32 ret;
-    asynStatus sts = C.read(&ret);
-    if(sts!=asynSuccess)
-        testOk(!defined, "Get %s -> Error %d\n", name, (int)sts);
-    else
-        testOk(defined && ret==expect,
-                "Get %s -> %d (actual %d)", name, (int)expect, (int)ret);
-}
-
-void testFlt(const char *name, double expect, bool defined=true)
-{
-    asynFloat64Client C("DUT", -1, name);
-    double ret;
-    asynStatus sts = C.read(&ret);
-    if(sts!=asynSuccess)
-        testOk(!defined, "Get %s -> Error %d\n", name, (int)sts);
-    else
-        testOk(defined && ret==expect,
-                "Get %s -> %f (actual %f)", name, expect, ret);
-}
-
-void testString(const char *name, const char *expect, bool defined=true) {
-    asynOctetClient C("DUT", -1, name);
-    std::vector<char> buf(strlen(expect)+10);
-    size_t act;
-    asynStatus sts = C.read(&buf[0], buf.size(), &act, NULL);
-    buf.back()='\0';
-    if(sts!=asynSuccess)
-        testOk(!defined, "Get %s -> Error %d\n", name, (int)sts);
-    else
-        testOk(defined && strcmp(expect, &buf[0])==0,
-                "Get %s -> \"%s\" (actual \"%s\")", name, expect, &buf[0]);
 }
 
 void prepareCam()
@@ -228,7 +149,7 @@ MAIN(testcam)
         cam.reset();
 
         testDiag("Create port");
-        if(aravisCameraConfig("DUT", "Aravis-GV01", 10, 10000, 0, 0)!=asynSuccess)
+        if(aravisCameraConfig("DUT", "Aravis-GV01", 0, 0, 0, 0)!=asynSuccess)
             testAbort("Unable to create port");
 
         asynSetTraceMask("DUT", -1, 0x3f);

--- a/aravisGigEApp/src/testhelper.h
+++ b/aravisGigEApp/src/testhelper.h
@@ -1,0 +1,88 @@
+#ifndef TESTHELPER_H
+#define TESTHELPER_H
+
+#include <epicsUnitTest.h>
+#include <asynPortClient.h>
+
+void setString(const char *name, const char *value)
+{
+    asynOctetClient C("DUT", -1, name);
+    size_t actual = 0;
+    asynStatus sts = C.write(value, strlen(value), &actual);
+    testOk(sts==asynSuccess && actual==strlen(value), "Set %s -> \"%s\"", name, value);
+}
+
+void setInt(const char *name, epicsInt32 val) {
+    asynInt32Client C("DUT", -1, name);
+    testOk(C.write(val)==asynSuccess, "Set %s = %d", name, (int)val);
+}
+
+epicsInt32 readInt(const char *name) {
+    asynInt32Client C("DUT", -1, name);
+    epicsInt32 ret;
+    int ok = C.read(&ret)==asynSuccess;
+    if(!ok) testAbort("Failed to read %s", name);
+    return ret;
+}
+
+void setFlt(const char *name, double val) {
+    asynFloat64Client C("DUT", -1, name);
+    testOk(C.write(val)==asynSuccess, "Set %s = %f", name, val);
+}
+
+void waitSyncd()
+{
+    epicsInt32 A = 0, B = 0;
+    testDiag("wait for scanner thread to make one cycle");
+    for(unsigned i=0; i<10; i++) {
+        if(i==9)
+            throw std::runtime_error("Timeout waiting for sync");
+
+        B = readInt("ARAVIS_SYNCD");
+        if(A!=0 && B!=0 && A!=B)
+            break;
+        A=B;
+        epicsThreadSleep(1.0);
+    }
+    testDiag("scanner cycle complete");
+}
+
+void testInt(const char *name, epicsInt32 expect, bool defined=true)
+{
+    asynInt32Client C("DUT", -1, name);
+    epicsInt32 ret;
+    asynStatus sts = C.read(&ret);
+    if(sts!=asynSuccess)
+        testOk(!defined, "Get %s -> Error %d\n", name, (int)sts);
+    else
+        testOk(defined && ret==expect,
+                "Get %s -> %d (actual %d)", name, (int)expect, (int)ret);
+}
+
+void testFlt(const char *name, double expect, bool defined=true)
+{
+    asynFloat64Client C("DUT", -1, name);
+    double ret;
+    asynStatus sts = C.read(&ret);
+    if(sts!=asynSuccess)
+        testOk(!defined, "Get %s -> Error %d\n", name, (int)sts);
+    else
+        testOk(defined && ret==expect,
+                "Get %s -> %f (actual %f)", name, expect, ret);
+}
+
+void testString(const char *name, const char *expect, bool defined=true) {
+    asynOctetClient C("DUT", -1, name);
+    std::vector<char> buf(strlen(expect)+10);
+    size_t act;
+    asynStatus sts = C.read(&buf[0], buf.size(), &act, NULL);
+    buf.back()='\0';
+    if(sts!=asynSuccess)
+        testOk(!defined, "Get %s -> Error %d\n", name, (int)sts);
+    else
+        testOk(defined && strcmp(expect, &buf[0])==0,
+                "Get %s -> \"%s\" (actual \"%s\")", name, expect, &buf[0]);
+}
+
+
+#endif // TESTHELPER_H

--- a/aravisGigEApp/src/testimage.cpp
+++ b/aravisGigEApp/src/testimage.cpp
@@ -1,0 +1,249 @@
+#include <string>
+#include <vector>
+#include <sstream>
+#include <deque>
+
+#include <stdio.h>
+#include <string.h>
+
+#include <epicsUnitTest.h>
+#include <testMain.h>
+
+#include <ADDriver.h> /* for AD*String */
+
+#include <epicsExit.h>
+#include <epicsExport.h>
+#include <epicsThread.h>
+#include <initHooks.h>
+#include <asynDriver.h>
+#include <asynPortClient.h>
+#include <shareLib.h>
+
+#include "ghelper.h"
+#include "adhelper.h"
+#include "testhelper.h"
+
+extern "C" {
+int asynSetTraceMask(const char *portName,int addr,int mask);
+
+extern REGISTRAR EPICS_EXPORT_PFUNC(aravisCameraRegister);
+
+// must match definition in aravisCamera.cpp
+int aravisCameraConfig(const char *portName, const char *cameraName,
+                                 int maxBuffers, size_t maxMemory, int priority, int stackSize);
+} // extern "C"
+
+namespace {
+
+struct NDImageListener : public asynPortClient
+{
+    NDImageListener(const char *portName, int addr, const char *drvInfo, double timeout=DEFAULT_TIMEOUT)
+    : asynPortClient(portName, addr, asynGenericPointerType, drvInfo, timeout)
+    {
+        pInterface_ = (asynGenericPointer *)pasynInterface_->pinterface;
+        if (pasynGenericPointerSyncIO->connect(portName, addr, &pasynUserSyncIO_, drvInfo))
+            throw std::runtime_error("pasynGenericPointerSyncIO->connect failed");
+        if (pInterface_->registerInterruptUser(pasynInterface_->drvPvt, pasynUser_,
+                                                          &cb, this, &interruptPvt_))
+            throw std::runtime_error("asynGenericPointer->registerInterruptUser failed");
+    }
+    ~NDImageListener()
+    {
+        pInterface_->cancelInterruptUser(pasynInterface_->drvPvt, pasynUser_, interruptPvt_);
+        pasynGenericPointerSyncIO->disconnect(pasynUserSyncIO_);
+    }
+
+    virtual void newImage(NDArray *borrowed)
+    {
+        bool wake;
+        {
+            epicsGuard<epicsMutex> G(lock);
+            wake = queue.empty();
+            if(borrowed->reserve()) {
+                asynPrint(pasynUser_, ASYN_TRACE_ERROR, "%s oh no!\n", __FUNCTION__);
+            } else {
+                queue.push_back(NDArrayPtr());
+                queue.back().reset(borrowed);
+            }
+        }
+        if(wake) {
+            evt.signal();
+        }
+    }
+
+    void tryWait(NDArrayPtr& ret, double timeout=-1) {
+        ret.reset();
+        epicsGuard<epicsMutex> G(lock);
+        while(queue.empty()) {
+            epicsGuardRelease<epicsMutex> U(G);
+            if(timeout>=0 && !evt.wait(timeout)) {
+                return; // timeout
+            } else if(timeout<0) {
+                evt.wait();
+            }
+        }
+        queue.front().swap(ret);
+        queue.pop_front();
+    }
+
+    static void cb(void *userPvt, asynUser *pasynUser,
+                   void *pointer)
+    {
+        NDImageListener *self = (NDImageListener*)userPvt;
+        try {
+            self->newImage((NDArray*)pointer);
+        } catch(std::exception& e) {
+            asynPrint(pasynUser, ASYN_TRACE_ERROR, "Unhandled exception in %s: %s\n",
+                       __FUNCTION__, e.what());
+        }
+    }
+
+    epicsMutex lock;
+    epicsEvent evt;
+    std::deque<NDArrayPtr> queue;
+
+    asynGenericPointer *pInterface_;
+};
+
+void setupParams()
+{
+    setInt(NDArrayCallbacksString, 1);
+    setInt(ADImageModeString, ADImageSingle);
+    setFlt(ADAcquirePeriodString, 0.1); // 10 Hz
+
+    setInt("ARAVIS_HWIMAGEMODE", 0);
+}
+
+void captureSingle()
+{
+    testDiag("Setup and capture a single frame");
+    NDImageListener images("DUT", -1, NDArrayDataString);
+
+    setInt(ADImageModeString, ADImageSingle);
+    testDiag("Start acquire");
+    setInt(ADAcquireString, 1);
+
+    NDArrayPtr img;
+    images.tryWait(img, 0.5);
+    if(!img.get())
+        testAbort("No frame");
+    testPass("Have frame");
+
+    {
+        NDArrayPtr img2;
+        images.tryWait(img2, 0.5);
+        testOk(!img2.get(), "Single acquire should not give a second image (%p)", img2.get());
+    }
+}
+
+void captureMultiple()
+{
+    const unsigned N = 5;
+    testDiag("Setup and capture %u frames", N);
+
+    NDImageListener images("DUT", -1, NDArrayDataString);
+
+    setInt(ADImageModeString, ADImageMultiple);
+    setInt(ADNumImagesString, N);
+
+    testDiag("Start acquire");
+    setInt(ADAcquireString, 1);
+
+    // collect arrays to ensure they aren't reused
+    std::vector<NDArrayPtr> img(N+1);
+
+    unsigned i;
+    for(i=0; i<img.size(); i++) {
+        images.tryWait(img[i], 0.5);
+        if(!img[i].get())
+            break;
+    }
+
+    testOk(i==N, "Received %u images", i);
+
+    bool pass = true;
+    for(i=0; i<img.size(); i++) {
+        for(unsigned j=i+1; j<img.size(); j++) {
+            pass &= img[i].get()!=img[j].get();
+            if(!pass)
+                testDiag("buffer reused %u %u %p", i, j, img[i].get());
+        }
+    }
+    testOk(pass, "No reuse of buffers still referenced");
+}
+
+void captureContinuous()
+{
+    // should be >=NRAW in aravisCamera.cpp
+    // to make sure consumed buffers are being replaced
+    const unsigned N = 25;
+
+    testDiag("Setup and capture %u frames", N);
+
+    NDImageListener images("DUT", -1, NDArrayDataString);
+
+    setInt(ADImageModeString, ADImageContinuous);
+
+    testDiag("Start acquire");
+    setInt(ADAcquireString, 1);
+
+    // collect arrays to ensure they aren't reused
+    std::vector<NDArrayPtr> img(N+1);
+
+    unsigned i;
+    for(i=0; i<img.size(); i++) {
+        images.tryWait(img[i], 0.5);
+        if(!img[i].get())
+            break;
+    }
+
+    testOk(i>=N, "Received %u images", i);
+
+    bool pass = true;
+    for(i=0; i<img.size(); i++) {
+        for(unsigned j=i+1; j<img.size(); j++) {
+            pass &= img[i].get()!=img[j].get();
+            if(!pass)
+                testDiag("buffer reused %u %u %p", i, j, img[i].get());
+        }
+    }
+    testOk(pass, "No reuse of buffers still referenced");
+}
+
+} // namespace
+
+MAIN(testimage)
+{
+    testPlan(0);
+
+    EPICS_EXPORT_PFUNC(aravisCameraRegister)();
+
+    testDiag("Create port");
+    if(aravisCameraConfig("DUT", "Aravis-GV01", 0, 0, 0, 0)!=asynSuccess)
+        testAbort("Unable to create port");
+
+    asynSetTraceMask("DUT", -1, 0x3f);
+
+    setupParams();
+
+    initHookAnnounce(initHookAfterIocRunning);
+    testDiag("Announced IocRunning");
+
+    testDiag("Wait for connect");
+    for(unsigned i=0; i<10; i++) {
+        if(i==9)
+            testAbort("No connect");
+        else if(readInt("ARAVIS_CONNECTION")==1)
+            break;
+        epicsThreadSleep(1.0);
+    }
+    testDiag("Connected");
+    waitSyncd();
+
+    captureSingle();
+    captureMultiple();
+    captureContinuous();
+
+    epicsExit(testDone());
+    return 2; // not reached
+}

--- a/aravisGigEApp/src/testimage.cpp
+++ b/aravisGigEApp/src/testimage.cpp
@@ -244,6 +244,8 @@ MAIN(testimage)
     captureMultiple();
     captureContinuous();
 
+    arv_shutdown();
+
     epicsExit(testDone());
     return 2; // not reached
 }

--- a/aravisGigEApp/src/testimage.cpp
+++ b/aravisGigEApp/src/testimage.cpp
@@ -35,10 +35,10 @@ int aravisCameraConfig(const char *portName, const char *cameraName,
 
 namespace {
 
-struct NDImageListener : public asynPortClient
+struct NDImageListener : public asynParamClient
 {
     NDImageListener(const char *portName, int addr, const char *drvInfo, double timeout=DEFAULT_TIMEOUT)
-    : asynPortClient(portName, addr, asynGenericPointerType, drvInfo, timeout)
+    : asynParamClient(portName, addr, asynGenericPointerType, drvInfo, timeout)
     {
         pInterface_ = (asynGenericPointer *)pasynInterface_->pinterface;
         if (pasynGenericPointerSyncIO->connect(portName, addr, &pasynUserSyncIO_, drvInfo))


### PR DESCRIPTION
This is a work in progress, and not yet ready to be merged, but it is (well past) time that I asked for some feedback.

I started this project in an attempt to fix/improve re-connection behavior.  This turned out to be much more involved, and much larger than I had originally thought.  While it isn't finished yet, it is basically working (w/ aravis fake camera and 2 real devices).  It can start up without a camera, and (re)connect without clearing ADAcquire (fully bumpless).  The c++ code has hooks to allow the camera name to be changed, though I haven't added this to the aravisCamera.template until I can figure out how to avoid autosave confusion.

There are two main functional changes.

The connection flow is made more continuous (modeled as a state machine).  Among other effects ```aravisCameraConfig()``` no longer blocks as the initial connection attempt is not a special case.  All calls which perform I/O are (I hope) checked for success, and the "connection" is reset when a timeout is detected.  Re-connect is tried every 5 seconds.

The other major change is in how synchronization is done between asynPortDriver parameters and aravis features.  Now aravisGigE acts as the master for "settings", which are always written to the camera (periodically while connected).  Other parameters are always read from the camera.  "settings" parameters are flagged in writeInt32() and writeFloat64() during the initial (PINI=YES) scan.  As settings are now push on (re)connect, the camera should come back to the same state even after a reset or power cycle.

Internally, I've introduce the Feature class, which keeps track of the mapping between asyn and aravis ID.  Each Feature has a single asynPortDriver parameter, and a list of possible aravis feature names in order of preference.  Each Port has ```interestingFeatures``` which holds all Feature instances, and ```activeFeatures``` which are those Feature which the currently connected camera provides.

A number of special cases previously handled with ```arv_camera_*()``` are now handled with Feature mappings created in the aravisCamera constructor.  For example, instead of calling ```arv_camera_get_vendor_name()``` a Feature maps "DeviceVendorName" to ADManufacturer.  There are still two special cases for PixelFormat and BinningMode where more than one parameter is involved.  Other mappings are created in drvUserCreate() as before.

Each Port now has two threads.  One "poller" (```aravisCamera::run()```) waits for frames, and manages state machine change of state.  The other "scanner" (```aravisCamera::runScanner()```) handles periodic synchronization between parameters and features.

I've tried to create two "unit-tests" which run against the aravis fake camera.  However, I have some issue getting these to work reliably.  I'll remove them unless I can fix this.

A TODO that I hope to get time for is to update makeDbAndEdl.py.  At minimum it needs to emit PINI=YES for "settings".  It also needs to be taught about the ```<ImposedAccessMode>``` tag to detect read-only parameters.  While I'm not sure how, I think it would be nice if VAL were initialized with the current feature value instead of always zero.

I also regret that this code will likely not build without some Makefile changes as I don't use the bundled aravis source (I just invoke pkg-config).  I haven't included Makefile changes except to add 3 additional executables (inspectcam, testcam, and testimage).

There are also a few minor items items flagged with TODO in the source.
