### PR TITLE
Update Makefile

### DIFF
--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -24,7 +24,7 @@ endif
 # install libs
 # TODO: shouldn't really do this, should get the aravisGgigeApp/src/Makefile to point to the vendor directory
 BIN_INSTALLS_Linux  += $(addprefix ../aravis-linux-x86_64/bin/, $(ARAVIS_LINUX_BINS))
-LIB_INSTALLS_Linux  += $(addprefix ../aravis-linux-x86_64/lib/, $(ARAVIS_LINUX_LIBS))
+LIB_INSTALLS_Linux  += $(addprefix ../aravis-linux-x86_64/lib64/, $(ARAVIS_LINUX_LIBS))
 ARAVISMAK = $(TOP)/vendor/aravis-linux-x86_64/Makefile	
 
 # depend on Makefile existing


### PR DESCRIPTION
The Aravis-Lib folder that is created by the Install.sh on a linux-x86_64 system has the name "lib64". There is no "lib" folder when building on for 64bit. I haven't tried to build on 32bit. Maybe the Makefile needs an if-clause?