### PR TITLE
Uncomment giomm-2.4

### DIFF
--- a/iocs/aravisGigEIOC/aravisGigEApp/src/Makefile
+++ b/iocs/aravisGigEIOC/aravisGigEApp/src/Makefile
@@ -17,7 +17,7 @@ PROD_SRCS += $(PROD_NAME)_registerRecordDeviceDriver.cpp $(PROD_NAME)Main.cpp
 # Add locally compiled object code
 PROD_LIBS += aravisCamera
 PROD_LIBS += aravis-0.6
-PROD_SYS_LIBS += giomm-2.4
+#PROD_SYS_LIBS += giomm-2.4
 PROD_SYS_LIBS += gio-2.0 gobject-2.0 gthread-2.0 glib-2.0
 PROD_SYS_LIBS += usb-1.0
 


### PR DESCRIPTION
I had to uncomment the line "PROD_SYS_LIBS += giomm-2.4" to be able to build the IOC, even though I have the latest libgiomm installed:
/usr/lib64/libgiomm-2.4.so.1
/usr/lib64/libgiomm-2.4.so.1.3.0

Or is the giomm-2.4 library necessary?